### PR TITLE
[TRTLLM-12297][fix] Multimodal hash for VideoData ignores extracted audio, breaks KV reuse

### DIFF
--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -644,14 +644,16 @@ def apply_mm_hashes(
                 if isinstance(frame, torch.Tensor):
                     frame = frame.detach().cpu().contiguous()
                 hasher.update(serialize_item(frame))
-            # TODO(TRTLLM-12297): also fold metadata["audio_samples"] /
-            # metadata["audio_sample_rate"] into the hash when present.
-            # extract_audio=true makes audio affect token counts and
-            # embeddings (see modeling_nemotron_nano.py
-            # _expand_video_placeholders_in_token_ids and
-            # get_num_tokens_per_video), but two videos with identical
-            # frames and different audio currently share the same MM hash —
-            # KV-cache reuse can return stale audio-conditioned states.
+            metadata = item.metadata
+            if (isinstance(metadata, dict) and "audio_samples" in metadata
+                    and "audio_sample_rate" in metadata):
+                audio_samples = metadata["audio_samples"]
+                if isinstance(audio_samples, torch.Tensor):
+                    audio_samples = audio_samples.detach().cpu().contiguous()
+                hasher.update(b"<audio>")
+                hasher.update(
+                    serialize_item(
+                        (audio_samples, metadata["audio_sample_rate"])))
         else:
             hasher.update(serialize_item(item))
 

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -310,6 +310,52 @@ def test_apply_mm_hashes_uuid_content_combined():
         "Different UUID + same content should produce different hashes"
 
 
+def test_apply_mm_hashes_video_audio_metadata_affects_hash():
+    """VideoData hashes include extracted audio when it affects model inputs."""
+    import numpy as np
+    from PIL import Image
+
+    from tensorrt_llm.inputs.multimodal import apply_mm_hashes
+    from tensorrt_llm.inputs.utils import VideoData
+
+    frames = [
+        Image.new("RGB", (2, 2), (10, 20, 30)),
+        Image.new("RGB", (2, 2), (40, 50, 60)),
+    ]
+    audio_a = np.array([0.0, 0.25, -0.5, 1.0], dtype=np.float32)
+    audio_a_copy = audio_a.copy()
+    audio_b = np.array([0.0, 0.25, -0.5, -1.0], dtype=np.float32)
+
+    def make_video(audio_samples=None, sample_rate=16000):
+        metadata = {}
+        if audio_samples is not None:
+            metadata = {
+                "audio_samples": audio_samples,
+                "audio_sample_rate": sample_rate,
+            }
+        return VideoData(frames=frames, metadata=metadata)
+
+    hashes_a, _ = apply_mm_hashes({"video": [make_video(audio_a)]})
+    hashes_a_copy, _ = apply_mm_hashes({"video": [make_video(audio_a_copy)]})
+    hashes_b, _ = apply_mm_hashes({"video": [make_video(audio_b)]})
+    hashes_a_different_rate, _ = apply_mm_hashes(
+        {"video": [make_video(audio_a, sample_rate=8000)]})
+    hashes_no_audio, _ = apply_mm_hashes({"video": [make_video()]})
+    hashes_frame_list, _ = apply_mm_hashes({"video": [frames]})
+
+    assert hashes_a["video"][0] == hashes_a_copy["video"][0]
+    assert hashes_a["video"][0] != hashes_b["video"][0]
+    assert hashes_a["video"][0] != hashes_a_different_rate["video"][0]
+    assert hashes_no_audio["video"][0] == hashes_frame_list["video"][0]
+
+    mm_uuids = {"video": ["shared-video-id"]}
+    hashes_uuid_a, _ = apply_mm_hashes({"video": [make_video(audio_a)]},
+                                       mm_uuids)
+    hashes_uuid_b, _ = apply_mm_hashes({"video": [make_video(audio_b)]},
+                                       mm_uuids)
+    assert hashes_uuid_a["video"][0] != hashes_uuid_b["video"][0]
+
+
 def test_int32_hexdigest_roundtrip():
     """Test that hexdigest_to_int32 and int32_to_hexdigest are inverses."""
     from tensorrt_llm.inputs.multimodal import (hexdigest_to_int32,


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

When `--media_io_kwargs '{"video": {"extract_audio": true'}}` is set, the video loader writes audio samples into `VideoData.metadata["audio_samples"]`, and Nemotron Nano V3 Omni now consumes those samples to produce additional `<so_*>` placeholder tokens and audio embeddings interleaved per video.

However, `_hash_content` in `tensorrt_llm/inputs/multimodal.py` hashes only `VideoData.frames` and ignores `metadata["audio_samples"]` / `metadata["audio_sample_rate"]`, so two requests with identical sampled frames but different audio share the same multimodal hash. With KV-cache reuse enabled, the second request can return stale audio-conditioned states from the first; the fix is to extend `_hash_content` for `VideoData` to fold audio samples and sample rate into the hash when present.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
